### PR TITLE
Updating scripts for deleting old images from Cloudinary

### DIFF
--- a/scripts/modules/Cloudinary.cjs
+++ b/scripts/modules/Cloudinary.cjs
@@ -1,51 +1,66 @@
-const cloudinary = require('cloudinary').v2;
+const cloudinary = require("cloudinary").v2;
 cloudinary.config({
-    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
-    api_key: process.env.CLOUDINARY_KEY,
-    api_secret: process.env.CLOUDINARY_SECRET
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_KEY,
+  api_secret: process.env.CLOUDINARY_SECRET
 });
 const { Readable } = require("stream");
-const { catchAsync } = require('./CatchAsync.cjs');
+const { catchAsync } = require("./CatchAsync.cjs");
 
 exports.default = cloudinary;
 
 exports.ping = catchAsync(async function () {
-    let res = await cloudinary.api.ping();
-    console.log(`Cloudinary connection ${res.status}`);
+  let res = await cloudinary.api.ping();
+  console.log(`Cloudinary connection ${res.status}`);
 });
 
 exports.usage = catchAsync(async function () {
-    let res = await cloudinary.api.usage();
-    console.log(res)
+  let res = await cloudinary.api.usage();
+  console.log(res);
 });
 
 exports.uploadStream = async buffer => {
-    return new Promise((resolve, reject) => {
-        const writeStream = cloudinary.uploader.upload_stream({ folder: 'pawper.dev', width: 500 }, (err, result) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(result)
-        });
-        const readStream = new Readable({
-            read() {
-                this.push(buffer);
-                this.push(null);
-            }
-        });
-        readStream.pipe(writeStream);
-    })
-}
-
-exports.deleteImages = async () => {
-    return new Promise((resolve, reject) => {
-        cloudinary.api.delete_resources_by_prefix('pawper.dev/', (err, result) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(result)
-        });
+  return new Promise((resolve, reject) => {
+    const writeStream = cloudinary.uploader.upload_stream({ folder: "pawper.dev", width: 500 }, (err, result) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(result);
     });
-}
+    const readStream = new Readable({
+      read() {
+        this.push(buffer);
+        this.push(null);
+      }
+    });
+    readStream.pipe(writeStream);
+  });
+};
+
+exports.getOldImages = async () => {
+  return new Promise((resolve, reject) => {
+    cloudinary.search
+      .expression("folder:pawper.dev")
+      .execute()
+      .then(result => {
+        let oldImagesPublicIds = result.resources.map(({ public_id }) => public_id);
+        resolve(oldImagesPublicIds);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+};
+
+exports.deleteImages = async imagesPublicIds => {
+  return new Promise((resolve, reject) => {
+    cloudinary.api.delete_resources(imagesPublicIds, (err, result) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(result);
+    });
+  });
+};

--- a/scripts/modules/GetPortfolioData.cjs
+++ b/scripts/modules/GetPortfolioData.cjs
@@ -1,75 +1,80 @@
 const { Octokit } = require("@octokit/rest");
 const octokit = new Octokit({
   auth: process.env.GITHUB
-})
-const { getProjectImage } = require('./GetProjectImage.cjs');
-const { deleteImages } = require('./Cloudinary.cjs');
+});
+const { getProjectImage } = require("./GetProjectImage.cjs");
+const { getOldImages, deleteImages } = require("./Cloudinary.cjs");
 
 exports.getPortfolioData = async function () {
-    try {
-        let results = await octokit.rest.search.repos({ q: 'user:pawper+topic:portfolio-project' });
+  try {
+    let results = await octokit.rest.search.repos({ q: "user:pawper+topic:portfolio-project" });
 
-        let projects = results.data.items.map(repo => ({
-            name: repo.name,
-            githubURL: repo.html_url,
-            description: repo.description,
-            topics: repo.topics,
-            webURL: repo.homepage
-        }));
+    let projects = results.data.items.map(repo => ({
+      name: repo.name,
+      githubURL: repo.html_url,
+      description: repo.description,
+      topics: repo.topics,
+      webURL: repo.homepage
+    }));
 
-        const { data } = await octokit.rest.repos.getContent({
-            mediaType: {
-              format: "raw",
-            },
-            owner: "ozh",
-            repo: "github-colors",
-            path: "colors.json",
+    const { data } = await octokit.rest.repos.getContent({
+      mediaType: {
+        format: "raw"
+      },
+      owner: "ozh",
+      repo: "github-colors",
+      path: "colors.json"
+    });
+    let languageColors = await JSON.parse(data);
+
+    let oldImagesPublicIds = await getOldImages();
+    console.log(oldImagesPublicIds);
+
+    await Promise.all(
+      projects.map(async (project, index) => {
+        let languages = await octokit.rest.repos.listLanguages({
+          owner: "Pawper",
+          repo: project.name
         });
-        let languageColors = await JSON.parse(data);
+        let sumLanguages = Object.values(languages.data).reduce((a, b) => a + b, 0);
+        for (const language in languages.data) {
+          languageLines = languages.data[language];
+          languages.data[language] = new Object();
+          languages.data[language]["percent"] = ((languageLines / sumLanguages) * 100).toFixed(2);
+          languages.data[language]["color"] = languageColors[language]["color"];
+        }
+        project.languages = languages.data;
 
-        deleteImages();
+        let topics = await octokit.rest.repos.getAllTopics({
+          owner: "Pawper",
+          repo: project.name
+        });
+        topics = topics.data.names.filter(topic => topic !== "portfolio-project");
+        project.topics = topics;
 
-        await Promise.all(projects.map(async (project, index) => {
-            let languages = await octokit.rest.repos.listLanguages({
-                owner: 'Pawper',
-                repo: project.name
-            });
-            let sumLanguages = Object.values(languages.data).reduce((a, b) => a + b, 0);
-            for (const language in languages.data) {
-                languageLines = languages.data[language]
-                languages.data[language] = new Object();
-                languages.data[language]['percent'] = (languageLines / sumLanguages * 100).toFixed(2);
-                languages.data[language]['color'] = languageColors[language]['color'];
-            }
-            project.languages = languages.data;
+        try {
+          const { data } = await octokit.rest.repos.getReadme({
+            mediaType: {
+              format: "html"
+            },
+            owner: "pawper",
+            repo: project.name
+          });
+          project.readme = data;
+        } catch (e) {
+          console.log(e);
+        }
 
-            let topics = await octokit.rest.repos.getAllTopics({
-                owner: 'Pawper',
-                repo: project.name
-            });
-            topics = topics.data.names.filter(topic => topic !== 'portfolio-project')
-            project.topics = topics;
+        let image = await getProjectImage(project.webURL, project.name);
+        project.image = image;
 
-            try {
-                const { data } = await octokit.rest.repos.getReadme({
-                    mediaType: {
-                      format: "html",
-                    },
-                    owner: "pawper",
-                    repo: project.name
-                });
-                project.readme = data;
-            } catch(e) {
-                console.log(e);
-            }
+        projects[index] = project;
+      }, undefined)
+    );
 
-            let image = await getProjectImage(project.webURL, project.name);
-            project.image = image;
-            
-            projects[index] = project
-        }, undefined));
-        return projects
-    } catch (e) {
-        console.log(e);
-    }
-}
+    deleteImages(oldImagesPublicIds);
+    return projects;
+  } catch (e) {
+    console.log(e);
+  }
+};


### PR DESCRIPTION
Fixed issue with pawper.dev screenshot showing missing images. Was caused by deleteImages(), which deletes everything in the Cloudinary folder, running prior to Puppeteer. Created getOldImages() to get an array of public_ids and updated deleteImages() to bulk delete using that array instead of deleting all folder contents.